### PR TITLE
Correct use of method yes_or_no in setup procedure

### DIFF
--- a/lib/puppet/provider/xldeploy_setup/pty.rb
+++ b/lib/puppet/provider/xldeploy_setup/pty.rb
@@ -33,7 +33,7 @@ Puppet::Type.type(:xldeploy_setup).provide(:pty)  do
 
         if line =~ /Options are yes or no./
           output.puts('no') if line_array[-1] =~ /Default values are used for all properties. To make changes to the default properties, please answer no./
-          output.puts("#{yes_or_no(resource[:ssl]}")) if line_array[-1] =~ /Would you like to enable SSL/
+          output.puts(yes_or_no(resource[:ssl])) if line_array[-1] =~ /Would you like to enable SSL/
           output.puts('no') if line_array[-1] =~ /Would you like to enable mutual SSL/
           output.puts('yes') if line_array[-1] =~ /Self-signed certificates do not work correctly with some versions of the Flash Player and some browsers!/
           output.puts('yes') if line_array[-1] =~ /Do you want to initialize the JCR repository/


### PR DESCRIPTION
Fixes this error

```
Oct  1 11:01:05 localhost puppet-master[7290]: /etc/puppet/modules/xldeploy/lib/puppet/provider/xldeploy_setup/pty.rb:90: syntax error, unexpected kEND, expecting '}' on node puppetagent.boxnet
Oct  1 11:01:05 localhost puppet-master[7290]: Could not autoload puppet/type/xldeploy_setup: Could not autoload puppet/provider/xldeploy_setup/pty: /etc/puppet/modules/xldeploy/lib/puppet/provider/xldeploy_setup/pty.rb:36: syntax error, unexpected '}', expecting ')'
Oct  1 11:01:05 localhost puppet-master[7290]: ...s("#{yes_or_no(resource[:ssl]}")) if line_array[-1] =~ /Woul...
```