### PR TITLE
Hundle characters like @ in password

### DIFF
--- a/lib/puppet_x/xebialabs/xldeploy/xldeploy.rb
+++ b/lib/puppet_x/xebialabs/xldeploy/xldeploy.rb
@@ -45,7 +45,7 @@ class Xldeploy
                 when 'delete' then Net::HTTP::Delete.new(uri.request_uri)
               end
 
-    request.basic_auth(uri.user, uri.password) if uri.user and uri.password
+    request.basic_auth(uri.user, URI.unescape(uri.password)) if uri.user and uri.password
     request.body = body unless body == ''
     request.content_type = 'application/xml'
 


### PR DESCRIPTION
password like: toto@s
should be set like that in the url : http://admin:toto%40s@localhost/deployit

URI.unescape(uri.password) will handle that.

Whithout it, I have the following error :

Error: /Stage[main]/Main/Xldeploy_ci[Applications/TEST]: Could not evaluate: cannot send request to deployit server 401/Cannot authenticate admin:<html>
<head>
<meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
<title>Error 401 Cannot authenticate admin</title>
</head>
<body><h2>HTTP ERROR 401</h2>
<p>Problem accessing /deployit/repository/exists/Applications/TEST. Reason:
<pre>    Cannot authenticate admin</pre></p><hr><i><small>Powered by Jetty://</small></i><hr/>

</body>
</html>